### PR TITLE
Code Review: Solve false Xcode 9.4 build warning (#18754)

### DIFF
--- a/peertalk.xcodeproj/project.pbxproj
+++ b/peertalk.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 		6A88FA27150D613800FC3647 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 0940;
 				TargetAttributes = {
 					EE158A5A1CBD3EB600A3E3F0 = {
 						CreatedOnToolsVersion = 7.3;


### PR DESCRIPTION
Code review for BohemianCoding/Sketch#18754 (“Solve false Xcode 9.4 build warning”):



Connect to BohemianCoding/Sketch#18754.