### PR TITLE
Code Review: Fix Xcode 10.2 localization warnings (24128)

### DIFF
--- a/peertalk.xcodeproj/project.pbxproj
+++ b/peertalk.xcodeproj/project.pbxproj
@@ -493,7 +493,7 @@
 			};
 			buildConfigurationList = 6A88FA2A150D613800FC3647 /* Build configuration list for PBXProject "peertalk" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,


### PR DESCRIPTION
> fix deprecated language #24128

connects to https://github.com/BohemianCoding/Sketch/issues/24128