### PR TITLE
Code Review: Run SketchMirrorHelper logic from main Sketch process (#38755)

### DIFF
--- a/peertalk/Peertalk.h
+++ b/peertalk/Peertalk.h
@@ -24,3 +24,5 @@ FOUNDATION_EXPORT const unsigned char PeertalkVersionString[];
 #import <Peertalk/PTChannel.h>
 #import <Peertalk/PTProtocol.h>
 #import <Peertalk/PTUSBHub.h>
+
+#pragma clang diagnostic pop

--- a/peertalk/PeertalkMac.h
+++ b/peertalk/PeertalkMac.h
@@ -16,6 +16,10 @@ FOUNDATION_EXPORT const unsigned char PeertalkVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <Peertalk/PublicHeader.h>
 
+// This warning needs to be switched off - Sketch itself has this warning on, so when FWs try to import
+// this FW, you get build errors. Instead of fixing this third party FW we wallpaper over the cracks.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wquoted-include-in-framework-header"
 
 #import <PeertalkMac/PTChannel.h>
 #import <peertalkMac/PTProtocol.h>

--- a/peertalk/PeertalkMac.h
+++ b/peertalk/PeertalkMac.h
@@ -24,3 +24,5 @@ FOUNDATION_EXPORT const unsigned char PeertalkVersionString[];
 #import <PeertalkMac/PTChannel.h>
 #import <peertalkMac/PTProtocol.h>
 #import <peertalkMac/PTUSBHub.h>
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
When building and including SketchMirrorHelper logic to the main Sketch logic, we get some warnings that were previously ignored by some code in Peertalk.h. It seems like we’re using PeertalkMac.h instead now, so do the same there.

connects sketch-hq/sketch#38755